### PR TITLE
Add Linux USBMon dissector

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -17,6 +17,7 @@ lib/NetPacket/IGMP.pm
 lib/NetPacket/IP.pm
 lib/NetPacket/TCP.pm
 lib/NetPacket/UDP.pm
+lib/NetPacket/USBMon.pm
 t/00-compile.t
 t/000-report-versions-tiny.t
 t/bug-37931.t

--- a/README
+++ b/README
@@ -24,6 +24,7 @@ implemented.
 	- IP
 	- UDP
 	- TCP
+	- USBMon
 
 It's pretty easy to add new protocols.  Just copy one of the existing
 modules and figure out an unpack string which will unpack the

--- a/lib/NetPacket/USBMon.pm
+++ b/lib/NetPacket/USBMon.pm
@@ -1,0 +1,354 @@
+package NetPacket::USBMon;
+
+use strict;
+use vars qw(@ISA @EXPORT_OK %EXPORT_TAGS);
+use NetPacket;
+
+BEGIN {
+    @ISA = qw(Exporter NetPacket);
+
+    @EXPORT_OK = qw(
+                    USB_TYPE_SUBMISSION USB_TYPE_CALLBACK USB_TYPE_ERROR
+                    USB_XFER_TYPE_ISO USB_XFER_TYPE_INTR
+                    USB_XFER_TYPE_CONTROL USB_XFER_TYPE_BULK
+                    USB_FLAG_SETUP_IRRELEVANT USB_FLAG_SETUP_RELEVANT
+                    USB_FLAG_DATA_ERROR USB_FLAG_DATA_INCOMING
+                    USB_FLAG_DATA_OUTGOING USB_FLAG_DATA_PRESENT
+                    USB_TYPE_VENDOR
+    );
+
+    %EXPORT_TAGS =(
+    ALL         => \@EXPORT_OK,
+    types       => [qw(USB_TYPE_SUBMISSION USB_TYPE_CALLBACK
+                       USB_TYPE_ERROR)],
+    xfer_types  => [qw(USB_XFER_TYPE_ISO USB_XFER_TYPE_INTR
+                       USB_XFER_TYPE_CONTROL USB_XFER_TYPE_BULK)],
+    setup_flags => [qw(USB_FLAG_SETUP_IRRELEVANT USB_FLAG_SETUP_RELEVANT)],
+    data_flags  => [qw(USB_FLAG_DATA_ERROR USB_FLAG_DATA_INCOMING
+                       USB_FLAG_DATA_OUTGOING USB_FLAG_DATA_PRESENT)],
+    setup_types => [qw(USB_TYPE_VENDOR)],
+);
+
+}
+
+use constant USB_TYPE_SUBMISSION        => 'S';
+use constant USB_TYPE_CALLBACK          => 'C';
+use constant USB_TYPE_ERROR             => 'E';
+
+use constant USB_XFER_TYPE_ISO          => 0;
+use constant USB_XFER_TYPE_INTR         => 1;
+use constant USB_XFER_TYPE_CONTROL      => 2;
+use constant USB_XFER_TYPE_BULK         => 3;
+
+use constant USB_FLAG_SETUP_IRRELEVANT  => '-';
+use constant USB_FLAG_SETUP_RELEVANT    => chr(0);
+
+use constant USB_FLAG_DATA_ERROR        => 'E';
+use constant USB_FLAG_DATA_INCOMING     => '<';
+use constant USB_FLAG_DATA_OUTGOING     => '>';
+use constant USB_FLAG_DATA_PRESENT      => chr(0);
+
+use constant USB_TYPE_VENDOR            => 0x40;
+
+sub decode
+{
+    my $class = shift;
+    my $packet = shift;
+    my $parent = shift;
+
+    my($id, $type, $xfer_type, $epnum, $devnum, $busnum, $flag_setup,
+        $flag_data, $ts_sec, $ts_usec, $status, $length, $len_cap,
+        $s, $interval, $start_frame, $xfer_flags, $ndesc, $rest) =
+        unpack('a8CCCCSCCa8liIIa8llLLa*', $packet);
+
+    # Try to grok quads. We may loose some address information with 32-bit
+    # Perl parsing 64-bit captures, or timestamp after 2038. Still the best
+    # we can do.
+    eval {
+      $id = unpack ('Q', $id);
+      $ts_sec = unpack ('Q', $ts_sec);
+    };
+    if ($@) {
+      ($id) = unpack ('LL', $id);
+      ($ts_sec) = unpack ('LL', $ts_sec);
+    }
+
+    my $self = {
+        _parent         => $parent,
+        _frame          => $packet,
+
+        id              => $id,
+        type            => chr($type),
+        xfer_type       => $xfer_type,
+        ep              => {
+            num         => ($epnum & 0x7f),
+            dir         => ($epnum & 0x80 ? 'IN' : 'OUT'),
+        },
+        devnum          => $devnum,
+        busnum          => $busnum,
+        flag_setup      => chr($flag_setup),
+        flag_data       => chr($flag_data),
+        ts_sec          => $ts_sec,
+        ts_usec         => $ts_usec,
+        status          => $status,
+        length          => $length,
+        len_cap         => $len_cap,
+        interval        => $interval,
+        start_frame     => $start_frame,
+        xfer_flags      => $xfer_flags,
+        ndesc           => $ndesc,
+    };
+
+    # Setup
+    if ($self->{flag_setup} ne USB_FLAG_SETUP_IRRELEVANT) {
+        my $setup = {};
+        my $rest;
+
+       ($setup->{bmRequestType}, $setup->{bRequest}, $rest)
+            = unpack('CCa*', $s);
+
+        if ($setup->{bmRequestType} & USB_TYPE_VENDOR) {
+           ($setup->{wValue}, $setup->{wIndex},
+                $setup->{wLength}) = unpack('S3', $rest);
+        } else {
+            # Unknown setup request;
+            $setup->{data} = $rest;
+        }
+
+        $self->{setup} = $setup;
+    }
+
+    # Isochronous descriptors
+    if ($self->{xfer_type} == USB_XFER_TYPE_ISO) {
+        my $iso = {};
+       ($iso->{error_count}, $iso->{numdesc}) = unpack('ii', $s);
+        $self->{iso} = $iso;
+    }
+
+    # Data
+    warn 'Payload length mismatch'
+        if length($rest) ne $self->{len_cap};
+    $self->{data} = $rest;
+
+    return bless $self, $class;
+}
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  use NetPacket::USBMon;
+
+  $usb = NetPacket::USBMon->decode($raw_pkt);
+
+=head1 DESCRIPTION
+
+C<NetPacket::USBMon> is a L<NetPacket> decoder of USB packets captured via
+Linux USBMon interface.
+
+=head2 Methods
+
+=over
+
+=item C<NetPacket::USBMon-E<gt>decode([RAW PACKET])>
+
+Decode a USB packet.
+
+=back
+
+=head2 Instance data
+
+The instance data for the C<NetPacket::UDP> object consists of
+the following fields.
+
+=over
+
+=item id
+
+An in-kernel address of the USB Request Block (URB). Stays the same for the
+transaction submission and completion.
+
+Might be truncatted when reading a 64-bit capture with 32-bit file.
+
+=item type
+
+URB type. Character 'S', 'C' or 'E', for constants USB_TYPE_SUBMISSION,
+USB_TYPE_CALLBACK or USB_TYPE_ERROR.
+
+=item xfer_type
+
+Transfer type. USB_XFER_TYPE_ISO, USB_XFER_TYPE_INTR, USB_XFER_TYPE_CONTROL
+or USB_XFER_TYPE_BULK.
+
+=item ep
+
+Endpoint identification.
+
+=over 8
+
+=item num
+
+Endpoint number.
+
+=item dir
+
+Transfer direction. "IN" or "OUT".
+
+=back
+
+=item devnum
+
+Device address.
+
+=item busnum
+
+Bus number.
+
+=item flag_setup
+
+Indicates whether setup is present and makes sense.
+
+=item flag_data
+
+Indicates whether data is present and makes sense.
+
+=item ts_sec
+
+Timestamp seconds since epoch. Subject to truncation with 32-bit Perl,
+which should be fine until 2038.
+
+=item ts_usec
+
+Timestamp microseconds.
+
+=item status
+
+URB status. Negative errno.
+
+=item length
+
+Length of data (submitted or actual).
+
+=item len_cap
+
+Delivered length
+
+=item setup
+
+Only present for packets with setup_flag turned on.
+Some contents are dependent on actual request type.
+
+=over 8
+
+=item bmRequestType
+
+=item bRequest
+
+=item wValue
+
+=item wIndex
+
+=item wLength
+
+=back
+
+=item iso
+
+Only present for isochronous transfers.
+
+=over 8
+
+=item error_count
+
+=item numdesc
+
+=back
+
+=item interval
+
+Isochronous packet response rate.
+
+=item start_frame
+
+Only applicable to isochronous transfers.
+
+
+=item xfer_flags
+
+A copy of URB's transfer_flags.
+
+=item ndesc
+
+Actual number of isochronous descriptors.
+
+=item data
+
+Packet payload.
+
+=back
+
+=head2 Exports
+
+=over
+
+=item default
+
+none
+
+=item exportable
+
+USB_TYPE_SUBMISSION, USB_TYPE_CALLBACK, USB_TYPE_ERROR, USB_XFER_TYPE_ISO,
+USB_XFER_TYPE_INTR, USB_XFER_TYPE_CONTROL, USB_XFER_TYPE_BULK,
+USB_FLAG_SETUP_IRRELEVANT, USB_FLAG_SETUP_RELEVANT, USB_FLAG_DATA_ERROR,
+USB_FLAG_DATA_INCOMING, USB_FLAG_DATA_OUTGOING, USB_FLAG_DATA_PRESENT,
+USB_TYPE_VENDOR
+
+=item tags
+
+The following tags group together related exportable items.
+
+=over
+
+=item C<:types>
+
+USB_TYPE_SUBMISSION, USB_TYPE_CALLBACK, USB_TYPE_ERROR
+
+=item C<:xfer_types>
+
+USB_XFER_TYPE_ISO, USB_XFER_TYPE_INTR, USB_XFER_TYPE_CONTROL, USB_XFER_TYPE_BULK
+
+=item C<:setup_flags>
+
+USB_FLAG_SETUP_IRRELEVANT, USB_FLAG_SETUP_RELEVANT
+
+=item C<:data_flags>
+
+USB_FLAG_DATA_ERROR, USB_FLAG_DATA_INCOMING, USB_FLAG_DATA_OUTGOING,
+USB_FLAG_DATA_PRESENT
+
+=item C<:setup_types>
+
+USB_TYPE_VENDOR
+
+=item C<:ALL>
+
+All the above exportable items.
+
+=back
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (c) 2013 Lubomir Rintel.
+
+This module is free software. You can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+Lubomir Rintel E<lt>lkundrak@v3.skE<gt>
+
+=cut

--- a/t/general.t
+++ b/t/general.t
@@ -11,5 +11,6 @@ use NetPacket::ICMP;
 use NetPacket::IGMP;
 use NetPacket::IP;
 use NetPacket::TCP;
+use NetPacket::USBMon;
 
 pass;

--- a/t/usbmon.t
+++ b/t/usbmon.t
@@ -1,0 +1,198 @@
+use strict;
+use warnings;
+
+use Test::More tests => 103;
+
+use NetPacket::USBMon qw/:ALL/;
+use Errno qw(:POSIX);
+
+my $frame;
+my $usbmon;
+
+# host -> device, GET DESCRIPTOR Request DEVICE
+$frame = binarize( <<'END_DATAGRAM' );
+40 21 9d fa 01 88 ff ff 53 02 80 0a 03 00 00 3c
+48 e4 0c 52 00 00 00 00 2f d7 06 00 8d ff ff ff
+28 00 00 00 00 00 00 00 80 06 00 01 00 00 28 00
+00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+
+#is $usbmon->{id} => 0xffff8801fa9d2140;
+is $usbmon->{type} => 'S';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_CONTROL;
+is $usbmon->{ep}{num} => 0;
+is $usbmon->{ep}{dir} => 'IN';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_RELEVANT;
+is $usbmon->{ts_sec} => 1376576584;
+is $usbmon->{ts_usec} => 448303;
+is $usbmon->{status} => -(EINPROGRESS);
+is $usbmon->{length} => 40;
+is $usbmon->{len_cap} => 0;
+is $usbmon->{xfer_flags} => 0x200;
+is $usbmon->{data} => '';
+
+# device -> host, GET DESCRIPTOR Response DEVICE
+$frame = binarize( <<'END_DATAGRAM' );
+40 21 9d fa 01 88 ff ff 43 02 80 0a 03 00 2d 00
+48 e4 0c 52 00 00 00 00 24 db 06 00 00 00 00 00
+12 00 00 00 12 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00
+12 01 00 02 00 00 00 40 71 1b 02 30 00 01 03 04
+02 01
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+is $usbmon->{type} => 'C';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_CONTROL;
+is $usbmon->{ep}{num} => 0;
+is $usbmon->{ep}{dir} => 'IN';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_IRRELEVANT;
+is $usbmon->{ts_sec} => 1376576584;
+is $usbmon->{ts_usec} => 449316;
+is $usbmon->{status} => 0;
+is $usbmon->{length} => 18;
+is $usbmon->{len_cap} => 18;
+is $usbmon->{xfer_flags} => 512;
+is length $usbmon->{data} => $usbmon->{len_cap};
+
+# host -> device, SET INTERFACE Request
+$frame = binarize( <<'END_DATAGRAM' );
+00 2b 9d fa 01 88 ff ff 53 02 00 0a 03 00 00 00
+65 e4 0c 52 00 00 00 00 23 62 07 00 8d ff ff ff
+00 00 00 00 00 00 00 00 40 0c 01 00 08 c0 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+is $usbmon->{type} => 'S';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_CONTROL;
+is $usbmon->{ep}{num} => 0;
+is $usbmon->{ep}{dir} => 'OUT';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_RELEVANT;
+is $usbmon->{ts_sec} => 1376576613;
+is $usbmon->{ts_usec} => 483875;
+is $usbmon->{status} => -(EINPROGRESS);
+is $usbmon->{length} => 0;
+is $usbmon->{len_cap} => 0;
+is $usbmon->{xfer_flags} => 0;
+is $usbmon->{data} => '';
+is $usbmon->{setup}{bmRequestType} => USB_TYPE_VENDOR;
+is $usbmon->{setup}{bRequest} => 12;
+is $usbmon->{setup}{wIndex} => 49160;
+is $usbmon->{setup}{wLength} => 0;
+is $usbmon->{setup}{wValue} => 1;
+
+# device -> host, SET INTERFACE Response
+$frame = binarize( <<'END_DATAGRAM' );
+00 2b 9d fa 01 88 ff ff 43 02 00 0a 03 00 2d 3e
+65 e4 0c 52 00 00 00 00 ae 61 07 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+is $usbmon->{type} => 'C';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_CONTROL;
+is $usbmon->{ep}{num} => 0;
+is $usbmon->{ep}{dir} => 'OUT';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_IRRELEVANT;
+is $usbmon->{ts_sec} => 1376576613;
+is $usbmon->{ts_usec} => 483758;
+is $usbmon->{status} => 0;
+is $usbmon->{length} => 0;
+is $usbmon->{len_cap} => 0;
+is $usbmon->{xfer_flags} => 0;
+is $usbmon->{data} => '';
+
+# host -> device, URB_CONTROL out
+$frame = binarize( <<'END_DATAGRAM' );
+00 2b 9d fa 01 88 ff ff 53 02 00 0a 03 00 00 00
+65 e4 0c 52 00 00 00 00 23 62 07 00 8d ff ff ff
+00 00 00 00 00 00 00 00 40 0c 01 00 08 c0 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+is $usbmon->{type} => 'S';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_CONTROL;
+is $usbmon->{ep}{num} => 0;
+is $usbmon->{ep}{dir} => 'OUT';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_RELEVANT;
+is $usbmon->{ts_sec} => 1376576613;
+is $usbmon->{ts_usec} => 483875;
+is $usbmon->{status} => -(EINPROGRESS);
+is $usbmon->{length} => 0;
+is $usbmon->{len_cap} => 0;
+is $usbmon->{xfer_flags} => 0;
+is $usbmon->{data} => '';
+
+# device -> host, URB_CONTROL out
+$frame = binarize( <<'END_DATAGRAM' );
+00 2b 9d fa 01 88 ff ff 43 02 00 0a 03 00 2d 3e
+65 e4 0c 52 00 00 00 00 1e 64 07 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+is $usbmon->{type} => 'C';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_CONTROL;
+is $usbmon->{ep}{num} => 0;
+is $usbmon->{ep}{dir} => 'OUT';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_IRRELEVANT;
+is $usbmon->{ts_sec} => 1376576613;
+is $usbmon->{ts_usec} => 484382;
+is $usbmon->{status} => 0;
+is $usbmon->{length} => 0;
+is $usbmon->{len_cap} => 0;
+is $usbmon->{xfer_flags} => 0;
+is $usbmon->{data} => '';
+
+# host -> device, URB_ISOCHRONOUS in
+$frame = binarize( <<'END_DATAGRAM' );
+00 ce 6b 19 01 88 ff ff 53 00 81 0a 03 00 2d 3c
+65 e4 0c 52 00 00 00 00 be 16 08 00 8d ff ff ff
+00 60 00 00 80 00 00 00 00 00 00 00 08 00 00 00
+01 00 00 00 00 00 00 00 02 02 00 00 08 00 00 00
+ee ff ff ff 00 00 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 0c 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 18 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 24 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 30 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 3c 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 48 00 00 00 0c 00 00 00 00 00 00
+ee ff ff ff 00 54 00 00 00 0c 00 00 00 00 00 00
+END_DATAGRAM
+
+$usbmon = NetPacket::USBMon->decode( $frame );
+is $usbmon->{type} => 'S';
+is $usbmon->{xfer_type} => USB_XFER_TYPE_ISO;
+is $usbmon->{ep}{num} => 1;
+is $usbmon->{ep}{dir} => 'IN';
+is $usbmon->{devnum} => 10;
+is $usbmon->{busnum} => 3;
+is $usbmon->{flag_setup} => USB_FLAG_SETUP_IRRELEVANT;
+is $usbmon->{ts_sec} => 1376576613;
+is $usbmon->{ts_usec} => 530110;
+is $usbmon->{status} => -(EINPROGRESS);
+is $usbmon->{length} => 24576;
+is $usbmon->{len_cap} => 128;
+is $usbmon->{xfer_flags} => 514;
+is length $usbmon->{data} => $usbmon->{len_cap};
+
+# Copied from t/tcp.t, uglified.
+sub binarize { return join '' => map { chr hex } split ' ', shift; }


### PR DESCRIPTION
This adds a dissector for USB packets as available from Linux USBMon interface
and a pcap library interface to it. The support is not complete, given the
complexity of the USB specification. Most common values are understood though,
the dissector is fairly useful at this point.

Encoder is not done yet.
A test suite for the decoder is present.
