### PR TITLE
Added some missing dates to Changes file

### DIFF
--- a/Changes
+++ b/Changes
@@ -76,7 +76,7 @@ revision history for NetPacket
    as the license of the patch clashes with the license of the
    distribution. (RT#62197)
 
-0.41_0
+0.41_0 unknown
  - Fixed bug 18941 - NetPacket::IP includes trailing  trash bytes in
    $ip->{data}
  - Fixed bug 7010 - IP flags field lost in IP::encode()
@@ -105,13 +105,16 @@ revision history for NetPacket
  - Updated license to Artistic 2.0
  - Fixed bad call to 'data()' in ICMP. Thanks to Ventz Petkov. (RT#52627)
 
-0.41.1
+0.41.1 unknown
  - Fixed bug 37931: export of ICMP_MASKREQ
  - Fixed UDP and TCP checksums for odd-sized packets
  - Fixed import from NetPacket::UDP
  - Fixed bug 37931: export of ICMP_MASKREQ
  - Added git repo and bug tracking info to META.yml
 
-0.04
+0.04 2003-05-21
  - Checksum offset fix, thanks to J. Hoagland for pointing this out.
+
+0.01 1999-04-24
+ - First release by TIMPOTTER
 


### PR DESCRIPTION
Hi Yanick,

I've added some missing dates to your Changes file, to make your file CPAN::Changes::Spec compliant.

A couple of notes:
- I could find evidence of release 0.41.1 on backpan, so have put the date as 'unknown'. Maybe it was never released, in which case you could change `unknown` to `not released`, or just merge the bullets into the next release.
- Release **0.41_0** is out of order, but given I couldn't find evidence of that (or an alternate release, such as 0.44_0?) on backpan either, I just marked the date as `unknown`. Looks like this was the first release you worked on when taking over, so maybe it was never released, or does backpan not archive dev releases? (Just checked, it does).

Cheers,
Neil
