### PR TITLE
Setup aliases at compile time

### DIFF
--- a/lib/NetPacket/ARP.pm
+++ b/lib/NetPacket/ARP.pm
@@ -99,8 +99,9 @@ sub decode {
 # packets contain no encapsulated data.
 #
 
-undef &arp_strip;
-*arp_strip = \&strip;
+sub arp_strip {
+  goto \&strip;
+}
 
 sub strip {
     return undef;

--- a/lib/NetPacket/Ethernet.pm
+++ b/lib/NetPacket/Ethernet.pm
@@ -107,8 +107,9 @@ $pkt);
 # Strip header from packet and return the data contained in it
 #
 
-undef &eth_strip;        # Create eth_strip alias
-*eth_strip = \&strip;
+sub eth_strip {
+  goto \&strip;
+}
 
 sub strip {
     my ($pkt) = @_;

--- a/lib/NetPacket/ICMP.pm
+++ b/lib/NetPacket/ICMP.pm
@@ -147,8 +147,9 @@ sub decode {
 # Strip a packet of its header and return the data
 #
 
-undef &icmp_strip;
-*icmpstrip = \&strip;
+sub icmpstrip {
+  goto \&strip;
+}
 
 sub strip {
     my ($pkt) = @_;

--- a/lib/NetPacket/IGMP.pm
+++ b/lib/NetPacket/IGMP.pm
@@ -118,8 +118,9 @@ sub decode {
 # packets contain no encapsulated data.
 #
 
-undef &igmp_strip;
-*igmp_strip = \&strip;
+sub igmp_strip {
+  goto \&strip;
+}
 
 sub strip {
     return undef;

--- a/lib/NetPacket/IP.pm
+++ b/lib/NetPacket/IP.pm
@@ -251,8 +251,9 @@ sub decode {
 # Strip header from packet and return the data contained in it
 #
 
-undef &ip_strip;           # Create ip_strip alias
-*ip_strip = \&strip;
+sub ip_strip { # Create ip_strip alias
+  goto \&strip;
+}
 
 sub strip {
     my ($pkt) = @_;

--- a/lib/NetPacket/TCP.pm
+++ b/lib/NetPacket/TCP.pm
@@ -30,8 +30,9 @@ our %EXPORT_TAGS = (
 # Strip header from packet and return the data contained in it
 #
 
-undef &tcp_strip;
-*tcp_strip = \&strip;
+sub tcp_strip {
+  goto \&strip;
+}
 
 sub strip {
     my ($pkt) = @_;

--- a/lib/NetPacket/UDP.pm
+++ b/lib/NetPacket/UDP.pm
@@ -46,8 +46,9 @@ sub decode {
 # Strip header from packet and return the data contained in it
 #
 
-undef &udp_strip;
-*udp_strip = \&strip;
+sub udp_strip {
+  goto \&strip;
+}
 
 sub strip {
     return decode(__PACKAGE__,shift)->{data};


### PR DESCRIPTION
    Avoid setting aliases at run time.
    Note that using a BEGIN block could also set them at
    compile time, but simply using goto there is good enough.

    PRC 201807 - Pull Request Challenge http://pullrequest.club