### PR TITLE
cpanfile: add recommended Net::Pcap{,Utils} from README

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,9 @@ requires "perl" => "v5.10.0";
 requires "strict" => "0";
 requires "warnings" => "0";
 
+recommends "Net::Pcap" => "0";
+recommends "Net::PcapUtils" => "0";
+
 on 'test' => sub {
   requires "ExtUtils::MakeMaker" => "0";
   requires "File::Spec" => "0";


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/december.html)

Since Net::Pcap and Net::PcapUtils were mentioned in the README, add them as `recommends` lines in the cpanfile for use on installs using `--with-recommends`.