### PR TITLE
Fix ICMPv6 checksum and IPv6 pseudo-header

### DIFF
--- a/lib/NetPacket/ICMPv6.pm
+++ b/lib/NetPacket/ICMPv6.pm
@@ -269,7 +269,7 @@ sub checksum {
     my ($ipv6) = @_;
 
     # Put the packet together for checksumming
-    my $len = length($self->{data}) + 32;
+    my $len = length($self->{data}) + 4;
     my $packet = $ipv6->pseudo_header($len, IP_PROTO_ICMPv6);
     $packet .= pack("CCna*", $self->{type}, $self->{code}, 0, $self->{data});
 

--- a/lib/NetPacket/IPv6.pm
+++ b/lib/NetPacket/IPv6.pm
@@ -198,7 +198,7 @@ sub pseudo_header {
     my $src_ip = inet_pton(AF_INET6, $self->{src_ip});
     my $dest_ip = inet_pton(AF_INET6, $self->{dest_ip});
 
-    return pack('a16a16Na3C', $src_ip, $dest_ip, $length, 0, $next_header);
+    return pack('a16a16Nx3C', $src_ip, $dest_ip, $length, $next_header);
 }
 
 #

--- a/t/icmpv6.t
+++ b/t/icmpv6.t
@@ -32,6 +32,7 @@ foreach my $datagram (@datagrams) {
   is length($icmpv6->{data}) => $test->{len}, 'Right message length';
 
   my $q = NetPacket::ICMPv6->decode( $icmpv6->encode( $ipv6 ) );
+  is $q->{cksum}, $test->{cksum}, 'Recalculated message checksum';
 
   foreach my $key (grep { !m/^_/ } keys %$icmpv6) {
     is_deeply $q->{$key}, $icmpv6->{$key}, "Round-trip $key";


### PR DESCRIPTION
* Add a test for checksum calculation in ICMPv6 which also uses the same IPv6 pseudo-header as UDP and TCP
* Fix IPv6 pseudo-header formation (fixes #16)
* Fix ICMPv6 packet length used for checksum